### PR TITLE
Bugfix/typo in header file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,6 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 /src/enc_temp_folder/
+
+build/
+!build/tools/EmbedFile.exe

--- a/src/lib/Convert.h
+++ b/src/lib/Convert.h
@@ -34,7 +34,7 @@ namespace sttp
     datetime_t FromUnixTime(time_t unixSOC, uint16_t milliseconds);
 
     // Convert Unix second of century and microseconds to DateTime
-    datetime_t FromUnixTimeMicro(time_t unixSOC, uint16_t microseconds);
+    datetime_t FromUnixTimeMicro(time_t unixSOC, uint32_t microseconds);
 
     // Converts a timestamp, in Ticks, to DateTime
     datetime_t FromTicks(int64_t ticks);


### PR DESCRIPTION
I fixed a tiny typo in the Convert.h header file that broke the build. This fix allows the following build to work on Ubuntu 22.04. There's some kind of gremlin on Ubuntu 24.04 that quietly prevents the examples from fully working (they mostly work, but published measurements are never received).

```bash
cmake -S . -B build
cd build
make -j$(($(nproc) - 2))
make -j$(($(nproc) - 2)) samples
cd ./src/Samples
# On one shell
./SimplePublish 12345
# On another shell
./SimpleSubscribe localhost 12345
```